### PR TITLE
Add AttachmentExternalisingStream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add AttachmentExternalisingStream ([#89](https://github.com/cucumber/message-streams/pull/89))
+
 ### Removed
 - Remove support for Node.js 14
 
 ## [4.0.1] - 2022-03-31
-
 ### Changed
 - Peer dependency of @cucumber/messages is now more permissive and simply request any version greater than 17.1.1
 
@@ -21,14 +23,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - `@cucumber/messages`is now a peer dependency. You have to add `@cucumber/messages` in your dependencies:
-  ```diff
-  {
-    "dependencies": {
-  +   "@cucumber/messages": "17.1.1",
-      "@cucumber/message-streams": "4.0.0",
-    }
-  }
-  ```
+```diff
+{
+"dependencies": {
+  - "@cucumber/messages": "17.1.1",
+"@cucumber/message-streams": "4.0.0",
+}
+}
+```
 
 ### Deprecated
 
@@ -59,6 +61,3 @@ by ignoring certain lines.
 [2.1.0]: https://github.com/cucumber/message-streams/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/cucumber/message-streams/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/cucumber/message-streams/releases/tag/v1.0.0
-
-
-<!-- Contributors in alphabetical order -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,15 @@
       "name": "@cucumber/message-streams",
       "version": "4.0.1",
       "license": "MIT",
+      "dependencies": {
+        "mime": "^3.0.0"
+      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
         "@cucumber/biome-config": "cucumber/biome-config#v0.1.0",
         "@cucumber/messages": "^32.0.0",
         "@tsconfig/recommended": "^1.0.13",
+        "@types/mime": "^3.0.4",
         "@types/mocha": "10.0.10",
         "@types/node": "22.19.17",
         "mocha": "11.7.5",
@@ -766,6 +770,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.4.tgz",
+      "integrity": "sha512-iJt33IQnVRkqeqC7PzBHPTC6fDlRNRW8vjrgqtScAhrmMwe8c4Eo7+fUGTa+XdWrpEgpyKWMYmi2dIwMAYRzPw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
@@ -1302,6 +1313,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/minipass": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build": "tsc --build tsconfig.build.json",
     "fix": "biome check --fix --error-on-warnings",
     "lint": "biome check --error-on-warnings",
-    "test": "mocha \"test/*Test.ts\"",
+    "test": "mocha \"src/**/*.spec.ts\" \"test/*Test.ts\"",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
@@ -25,6 +25,7 @@
     "@cucumber/biome-config": "cucumber/biome-config#v0.1.0",
     "@cucumber/messages": "^32.0.0",
     "@tsconfig/recommended": "^1.0.13",
+    "@types/mime": "^3.0.4",
     "@types/mocha": "10.0.10",
     "@types/node": "22.19.17",
     "mocha": "11.7.5",
@@ -38,5 +39,8 @@
     "url": "https://github.com/cucumber/message-streams/issues"
   },
   "homepage": "https://github.com/cucumber/message-streams#readme",
-  "keywords": []
+  "keywords": [],
+  "dependencies": {
+    "mime": "^3.0.0"
+  }
 }

--- a/src/AttachmentExternalisingStream.spec.ts
+++ b/src/AttachmentExternalisingStream.spec.ts
@@ -1,0 +1,211 @@
+import assert from 'node:assert'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { type Attachment, AttachmentContentEncoding, type Envelope } from '@cucumber/messages'
+import toArray from '../test/toArray'
+import type { AttachmentExternalisingStreamOptions } from './AttachmentExternalisingStream'
+import { AttachmentExternalisingStream } from './AttachmentExternalisingStream'
+
+async function collectMessages(
+  envelopes: Envelope[],
+  options: AttachmentExternalisingStreamOptions
+): Promise<Envelope[]> {
+  const stream = new AttachmentExternalisingStream(options)
+  for (const envelope of envelopes) {
+    stream.write(envelope)
+  }
+  stream.end()
+  return toArray(stream)
+}
+
+function getAttachment(envelope: Envelope): Attachment {
+  assert.ok(envelope.attachment, 'expected envelope to have an attachment')
+  return envelope.attachment
+}
+
+describe('AttachmentExternalisingStream', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cucumber-html-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  it('passes through all messages when behaviour is false', async () => {
+    const envelopes: Envelope[] = [
+      { testRunStarted: { timestamp: { seconds: 0, nanos: 0 } } },
+      {
+        attachment: {
+          body: Buffer.from('hello').toString('base64'),
+          contentEncoding: AttachmentContentEncoding.BASE64,
+          mediaType: 'image/png',
+        },
+      },
+    ]
+    const result = await collectMessages(envelopes, { behaviour: false, directory: tmpDir })
+    assert.deepStrictEqual(result, envelopes)
+    assert.deepStrictEqual(fs.readdirSync(tmpDir), [])
+  })
+
+  it('passes through non-attachment messages unchanged', async () => {
+    const envelope: Envelope = {
+      testRunStarted: { timestamp: { seconds: 0, nanos: 0 } },
+    }
+    const result = await collectMessages([envelope], { behaviour: true, directory: tmpDir })
+    assert.deepStrictEqual(result, [envelope])
+  })
+
+  it('externalises a BASE64 attachment', async () => {
+    const body = Buffer.from('hello').toString('base64')
+    const envelope: Envelope = {
+      attachment: {
+        body,
+        contentEncoding: AttachmentContentEncoding.BASE64,
+        mediaType: 'image/png',
+      },
+    }
+    const result = await collectMessages([envelope], { behaviour: true, directory: tmpDir })
+    const attachment = getAttachment(result[0])
+    assert.strictEqual(attachment.body, '')
+    assert.strictEqual(attachment.contentEncoding, AttachmentContentEncoding.IDENTITY)
+    assert.ok(attachment.url)
+    assert.match(attachment.url, /^\.\/attachment-.*\.png$/)
+    const written = fs.readFileSync(path.join(tmpDir, attachment.url.slice(2)))
+    assert.deepStrictEqual(written, Buffer.from('hello'))
+  })
+
+  it('externalises an IDENTITY attachment', async () => {
+    const envelope: Envelope = {
+      attachment: {
+        body: '{"some":"json"}',
+        contentEncoding: AttachmentContentEncoding.IDENTITY,
+        mediaType: 'application/json',
+      },
+    }
+    const result = await collectMessages([envelope], { behaviour: true, directory: tmpDir })
+    const attachment = getAttachment(result[0])
+    assert.strictEqual(attachment.body, '')
+    assert.ok(attachment.url)
+    assert.match(attachment.url, /^\.\/attachment-.*\.json$/)
+    const written = fs.readFileSync(path.join(tmpDir, attachment.url.slice(2)), 'utf-8')
+    assert.strictEqual(written, '{"some":"json"}')
+  })
+
+  it('does not externalise text/x.cucumber.log+plain', async () => {
+    const envelope: Envelope = {
+      attachment: {
+        body: 'some log output',
+        contentEncoding: AttachmentContentEncoding.IDENTITY,
+        mediaType: 'text/x.cucumber.log+plain',
+      },
+    }
+    const result = await collectMessages([envelope], { behaviour: true, directory: tmpDir })
+    const attachment = getAttachment(result[0])
+    assert.strictEqual(attachment.body, 'some log output')
+    assert.strictEqual(attachment.url, undefined)
+  })
+
+  it('does not externalise text/uri-list', async () => {
+    const envelope: Envelope = {
+      attachment: {
+        body: 'https://example.com',
+        contentEncoding: AttachmentContentEncoding.IDENTITY,
+        mediaType: 'text/uri-list',
+      },
+    }
+    const result = await collectMessages([envelope], { behaviour: true, directory: tmpDir })
+    const attachment = getAttachment(result[0])
+    assert.strictEqual(attachment.body, 'https://example.com')
+    assert.strictEqual(attachment.url, undefined)
+  })
+
+  it('externalises only attachments matching the given patterns', async () => {
+    const envelopes: Envelope[] = [
+      {
+        attachment: {
+          body: Buffer.from('image data').toString('base64'),
+          contentEncoding: AttachmentContentEncoding.BASE64,
+          mediaType: 'image/png',
+        },
+      },
+      {
+        attachment: {
+          body: Buffer.from('video data').toString('base64'),
+          contentEncoding: AttachmentContentEncoding.BASE64,
+          mediaType: 'video/mp4',
+        },
+      },
+      {
+        attachment: {
+          body: 'some text',
+          contentEncoding: AttachmentContentEncoding.IDENTITY,
+          mediaType: 'text/plain',
+        },
+      },
+    ]
+    const result = await collectMessages(envelopes, {
+      behaviour: ['image/*', 'video/*'],
+      directory: tmpDir,
+    })
+    const image = getAttachment(result[0])
+    assert.strictEqual(image.body, '')
+    assert.ok(image.url)
+    const video = getAttachment(result[1])
+    assert.strictEqual(video.body, '')
+    assert.ok(video.url)
+    const text = getAttachment(result[2])
+    assert.strictEqual(text.body, 'some text')
+    assert.strictEqual(text.url, undefined)
+  })
+
+  it('supports exact media type in patterns', async () => {
+    const envelopes: Envelope[] = [
+      {
+        attachment: {
+          body: Buffer.from('png data').toString('base64'),
+          contentEncoding: AttachmentContentEncoding.BASE64,
+          mediaType: 'image/png',
+        },
+      },
+      {
+        attachment: {
+          body: Buffer.from('jpeg data').toString('base64'),
+          contentEncoding: AttachmentContentEncoding.BASE64,
+          mediaType: 'image/jpeg',
+        },
+      },
+    ]
+    const result = await collectMessages(envelopes, {
+      behaviour: ['image/png'],
+      directory: tmpDir,
+    })
+    const png = getAttachment(result[0])
+    assert.strictEqual(png.body, '')
+    assert.ok(png.url)
+    const jpeg = getAttachment(result[1])
+    assert.strictEqual(jpeg.body, Buffer.from('jpeg data').toString('base64'))
+    assert.strictEqual(jpeg.url, undefined)
+  })
+
+  it('does not externalise always-inlined types even when matching patterns', async () => {
+    const envelope: Envelope = {
+      attachment: {
+        body: 'some log output',
+        contentEncoding: AttachmentContentEncoding.IDENTITY,
+        mediaType: 'text/x.cucumber.log+plain',
+      },
+    }
+    const result = await collectMessages([envelope], {
+      behaviour: ['text/*'],
+      directory: tmpDir,
+    })
+    const attachment = getAttachment(result[0])
+    assert.strictEqual(attachment.body, 'some log output')
+    assert.strictEqual(attachment.url, undefined)
+  })
+})

--- a/src/AttachmentExternalisingStream.ts
+++ b/src/AttachmentExternalisingStream.ts
@@ -1,0 +1,105 @@
+import { writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { Transform, type TransformCallback } from 'node:stream'
+
+import {
+  type Attachment,
+  AttachmentContentEncoding,
+  type Envelope,
+  IdGenerator,
+} from '@cucumber/messages'
+import mime from 'mime'
+
+const alwaysInlinedTypes = ['text/x.cucumber.log+plain', 'text/uri-list']
+
+const encodingsMap: Record<string, BufferEncoding> = {
+  IDENTITY: 'utf-8',
+  BASE64: 'base64',
+}
+
+export interface AttachmentExternalisingStreamOptions {
+  behaviour?: boolean | ReadonlyArray<string>
+  directory: string
+  newId?: IdGenerator.NewId
+}
+
+export class AttachmentExternalisingStream extends Transform {
+  private readonly writeOperations: Promise<void>[] = []
+  private readonly options: Required<AttachmentExternalisingStreamOptions>
+
+  constructor(options: AttachmentExternalisingStreamOptions) {
+    super({ objectMode: true })
+    this.options = {
+      behaviour: false,
+      ...options,
+      newId: options.newId ?? IdGenerator.uuid(),
+    }
+  }
+
+  public _transform(envelope: Envelope, _encoding: string, callback: TransformCallback): void {
+    if (envelope.attachment && this.shouldExternalise(envelope.attachment)) {
+      const { attachment, writeOperation } = rewriteAttachment(
+        envelope.attachment,
+        this.options.directory,
+        this.options.newId
+      )
+      this.push({ ...envelope, attachment })
+      if (writeOperation) {
+        this.writeOperations.push(writeOperation)
+      }
+    } else {
+      this.push(envelope)
+    }
+    callback()
+  }
+
+  private shouldExternalise(attachment: Attachment): boolean {
+    const { behaviour } = this.options
+    if (Array.isArray(behaviour)) {
+      return (
+        !alwaysInlinedTypes.includes(attachment.mediaType) &&
+        behaviour.some((pattern) => matchMediaType(attachment.mediaType, pattern))
+      )
+    }
+    return behaviour === true
+  }
+
+  public _flush(callback: TransformCallback): void {
+    Promise.all(this.writeOperations).then(
+      () => callback(),
+      (err) => callback(err)
+    )
+  }
+}
+
+function matchMediaType(mediaType: string, pattern: string): boolean {
+  const [patternType, patternSubtype] = pattern.split('/')
+  const [type, subtype] = mediaType.split('/')
+  return patternType === type && (patternSubtype === '*' || patternSubtype === subtype)
+}
+
+function rewriteAttachment(
+  original: Attachment,
+  directory: string,
+  newId: () => string
+): { attachment: Attachment; writeOperation?: Promise<void> } {
+  if (alwaysInlinedTypes.includes(original.mediaType)) {
+    return { attachment: original }
+  }
+  let filename = `attachment-${newId()}`
+  const extension = mime.getExtension(original.mediaType)
+  if (extension) {
+    filename += `.${extension}`
+  }
+  const writeOperation = writeFile(
+    path.join(directory, filename),
+    Buffer.from(original.body, encodingsMap[original.contentEncoding])
+  )
+  const attachment: Attachment = {
+    ...original,
+    contentEncoding: AttachmentContentEncoding.IDENTITY,
+    body: '',
+    url: `./${filename}`,
+  }
+  return { attachment, writeOperation }
+}

--- a/src/AttachmentExternalisingStream.ts
+++ b/src/AttachmentExternalisingStream.ts
@@ -18,11 +18,34 @@ const encodingsMap: Record<string, BufferEncoding> = {
 }
 
 export interface AttachmentExternalisingStreamOptions {
+  /**
+   * Controls which attachments are externalised:
+   * - `false` (or omitted): pass through all messages unchanged
+   * - `true`: externalise every attachment
+   * - `ReadonlyArray<string>`: externalise only attachments whose `mediaType`
+   *   matches one of the given patterns (e.g. `['image/*', 'video/*']`),
+   *   where the subtype may be `*` to match any subtype
+   * @remarks
+   * Attachments with certain media types (e.g. `text/x.cucumber.log+plain`)
+   * are always kept inline regardless of this option.
+   */
   behaviour?: boolean | ReadonlyArray<string>
+  /**
+   * Directory to write externalised attachment files into
+   */
   directory: string
+  /**
+   * Function used to generate unique IDs for attachment filenames. Defaults
+   * to a UUID generator
+   */
   newId?: IdGenerator.NewId
 }
 
+/**
+ * A transform stream that externalises attachment bodies from a stream of
+ * {@link Envelope}s by writing them to files in a given directory and
+ * replacing each body with a relative URL pointing to the written file.
+ */
 export class AttachmentExternalisingStream extends Transform {
   private readonly writeOperations: Promise<void>[] = []
   private readonly options: Required<AttachmentExternalisingStreamOptions>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import MessageToNdjsonStream from './MessageToNdjsonStream'
 import NdjsonToMessageStream from './NdjsonToMessageStream'
 
+export * from './AttachmentExternalisingStream'
+
 export { MessageToNdjsonStream, NdjsonToMessageStream }


### PR DESCRIPTION
### 🤔 What's changed?

Adds a new stream class for externalising attachments per some given options.

This can precede `CucumberHtmlStream` in a pipeline that produces an HTML report, externalising attachments as needed.

### ⚡️ What's your motivation? 

https://github.com/cucumber/cucumber-js/issues/2781

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
